### PR TITLE
add spring boot dependency and vaadin starter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,15 +3,32 @@ plugins {
     id 'java'
 	id 'eclipse'
     id 'application'
+    id 'com.vaadin' version '0.8.0'
+    id 'org.springframework.boot' version '2.2.4.RELEASE'
+    id 'io.spring.dependency-management' version '1.0.9.RELEASE'
 }
 
 repositories {
     jcenter()
 }
 
+ext {
+    set('vaadinVersion', "14.3.0")
+}
+
+dependencyManagement {
+    imports {
+        mavenBom "com.vaadin:vaadin-bom:${vaadinVersion}"
+    }
+}
+
 dependencies {
     implementation 'com.google.guava:guava:29.0-jre'
+    implementation 'com.vaadin:vaadin-spring-boot-starter'
 
+    testImplementation('org.springframework.boot:spring-boot-starter-test') {
+        exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
+    }
     testImplementation 'junit:junit:4.13'
 }
 


### PR DESCRIPTION
Add in `build.gradle` file Spring Boot and Vaadin starter. Spring Boot version is the one that is 100% compatible with Vaadin.